### PR TITLE
Tilt support

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,34 @@ Bundle 'himl' gem to your project.
 The gem contains the Himl template handler for Rails.
 You need no extra configurations for your Rails app to render `*.himl` templates.
 
+## Tilt support
+
+The gem comes with [tilt](https://github.com/rtomayko/tilt) support and
+thus can be used with frameworks such as [Hanami](https://hanamirb.org).
+
+Use following `gem` line:
+
+```rb
+gem 'tilt' # if needed
+gem 'himl', require: 'himl/tilt'
+```
+
+Now you can render Himl templates via Tilt:
+
+```rb
+puts Tilt['himl'].new { <<TEMPLATE }.render(self, name: 'John')
+<div>
+  <h1>Hello, <%= name %></h1>
+TEMPALTE
+```
+
+and will get
+
+```html
+<div>
+  <h1>Hello, John</h1>
+</div>
+```
 
 ## Runtime Performance
 

--- a/himl.gemspec
+++ b/himl.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency 'test-unit'
   spec.add_development_dependency 'byebug'
+  spec.add_development_dependency 'tilt'
 end

--- a/lib/himl/tilt.rb
+++ b/lib/himl/tilt.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'tilt'
+require 'tilt/erb'
+require 'himl/parser'
+
+module Tilt
+  class HimlTemplate < ERBTemplate
+    def prepare
+      parser = Himl::Parser.new
+      parser.call(@data)
+      @data = parser.to_erb
+      options[:trim] = '-<>' unless options.key?(:trim)
+      super
+    end
+  end
+  register 'himl', HimlTemplate
+end

--- a/test/tilt_test.rb
+++ b/test/tilt_test.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+require 'himl/tilt'
+require 'tempfile'
+
+class TiltTest < Test::Unit::TestCase
+  private def file_with_content(content)
+    Tempfile.open do |tmp|
+      tmp.print content
+      tmp
+    end
+  end
+
+  private def parse(content, scope=nil, **locals, &block)
+    file = file_with_content(content)
+    scope ||= Object.new
+    Tilt::HimlTemplate.new(file).render(scope, locals, &block)
+  end
+
+  def test_without_args
+    assert_equal <<~HTML, parse(<<~TEMPLATE)
+    <div>
+      <h1>Hello, world</h1>
+    </div>
+    HTML
+    <div>
+      <h1>Hello, world</h1>
+    TEMPLATE
+  end
+
+  def test_with_locals
+    assert_equal <<~HTML, parse(<<~TEMPLATE, name1: 'Alice', name2: 'Bob')
+    <div>
+      <ul>
+        <li>Hello, Alice</li>
+        <li>Hello, Bob</li>
+      </ul>
+    </div>
+    HTML
+    <div>
+      <ul>
+        <li>Hello, <%= name1 %></li>
+        <li>Hello, <%= name2 %></li>
+    TEMPLATE
+  end
+
+  def test_with_locals_and_code
+    assert_equal <<~HTML, parse(<<~TEMPLATE, names: %w[Alice Bob])
+    <div>
+      <ul>
+          <li>Hello, Alice</li>
+          <li>Hello, Bob</li>
+      </ul>
+    </div>
+    HTML
+    <div>
+      <ul>
+        <%- names.each do |name| -%>
+          <li>Hello, <%= name %></li>
+        <%- end -%>
+    TEMPLATE
+  end
+
+  def test_with_scope
+    charlie = Object.new.tap {|o| o.instance_variable_set(:@name, 'Charlie') }
+    assert_equal <<~HTML, parse(<<~TEMPLATE, charlie)
+    <div>
+      <ul>
+        <li>Hello, Charlie</li>
+      </ul>
+    </div>
+    HTML
+    <div>
+      <ul>
+        <li>Hello, <%= @name %></li>
+    TEMPLATE
+  end
+
+  def test_with_block
+    assert_equal <<~HTML, (parse(<<~TEMPLATE) { "hello" })
+    hello
+    HTML
+    <%= yield %>
+    TEMPLATE
+  end
+
+  def test_registration
+    file = Tempfile.new(['', '.himl'])
+    assert_equal Tilt::HimlTemplate, Tilt.new(file.path).class
+  end
+end


### PR DESCRIPTION
This PR enables using Himl via [Tilt](https://github.com/rtomayko/tilt), a generic interface to multiple Ruby template engines, which is used by some web application frameworks, [Sinatra](https://github.com/sinatra/sinatra) and [Hanami](https://github.com/hanami/view) to name a few.